### PR TITLE
Fix provenance default format

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -32,21 +32,18 @@ func downloadCmd(args []string) error {
 	var format string
 	img := f.Arg(f.NArg() - 1)
 	if f.Arg(0) == "provenance" {
-		f.StringVar(&format, "format", "slsav1", "Format used to return the information.")
+		f.StringVar(&format, "format", "slsav0.2", "The format for the Provenance output. Supported values are slsav0.2 (default) and slsav1.")
 
 		err := f.Parse(args[1:])
 		if err != nil {
 			return err
 		}
 
-		if format == "slsav1" {
-			return provenanceSlsaV1(f.Arg(0))
-		}
-		return provenanceCmd(img)
+		return provenanceCmd(img, format)
 	}
 
 	if f.Arg(0) == "sbom" {
-		f.StringVar(&format, "format", "spdxjson", "Format used to return the information.")
+		f.StringVar(&format, "format", "spdxjson", "The format for the SBOM output. Supported values are spdxjson (default) and cyclonedxjson.")
 
 		err := f.Parse(args[1:])
 		if err != nil {

--- a/cmd/provenance.go
+++ b/cmd/provenance.go
@@ -10,19 +10,22 @@ import (
 	"github.com/rancherlabs/slsactl/internal/provenance"
 )
 
-func provenanceCmd(img string) error {
-	return writeContent(img, "{{json .Provenance}}", os.Stdout)
-}
+func provenanceCmd(img, format string) error {
+	switch format {
+	case "slsav0.2":
+		return writeContent(img, "{{json .Provenance}}", os.Stdout)
+	case "slsav1":
+		var buf bytes.Buffer
+		err := writeContent(img, "{{json .Provenance}}", &buf)
+		if err != nil {
+			return err
+		}
 
-func provenanceSlsaV1(img string) error {
-	var buf bytes.Buffer
-	err := writeContent(img, "{{json .Provenance}}", &buf)
-	if err != nil {
-		return err
+		convert(buf.Bytes(), os.Stdout)
+		return nil
 	}
 
-	convert(buf.Bytes(), os.Stdout)
-	return nil
+	return fmt.Errorf("invalid format %q: supported values are slsav0.2 or slsav1", format)
 }
 
 func convert(data []byte, w io.Writer) {


### PR DESCRIPTION
Previously the default format was set to `slsav1`, which resulted on the provenance not changing from `v0.2` to `v1`.