### PR TITLE
General improvements on sbom and provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ slsactl download provenance rancher/cis-operator:v1.0.15
 slsactl download provenance --format=slsav1 rancher/cis-operator:v1.0.15
 ```
 
+By default, the returned provenance would be for `linux/amd64`. To select a
+different platform use `--platform`.
+
 ### SBOM
 The latest container images have baked into them a layer containing their SPDX
 SBOM, which can be extracted with:
@@ -36,6 +39,9 @@ If Cyclonedx is required instead:
 ```bash
 slsactl download sbom -format cyclonedxjson rancher/cis-operator:v1.0.15
 ```
+
+By default, the returned provenance would be for `linux/amd64`. To select a
+different platform use `--platform`.
 
 Note that images that haven't got a SBOM layer attached to them, the same
 command will generate a SBOM manifest on-demand, which will take longer.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ slsactl download provenance rancher/cis-operator:v1.0.15
 slsactl download provenance --format=slsav1 rancher/cis-operator:v1.0.15
 ```
 
-By default, the returned provenance would be for `linux/amd64`. To select a
-different platform use `--platform`.
+By default, the returned provenance will be for `linux/amd64`, if one exists.
+To select a different platform use `--platform`.
 
 ### SBOM
 The latest container images have baked into them a layer containing their SPDX
@@ -40,8 +40,8 @@ If Cyclonedx is required instead:
 slsactl download sbom -format cyclonedxjson rancher/cis-operator:v1.0.15
 ```
 
-By default, the returned provenance would be for `linux/amd64`. To select a
-different platform use `--platform`.
+By default, the returned provenance will be for `linux/amd64`, if one exists.
+To select a different platform use `--platform`.
 
 Note that images that haven't got a SBOM layer attached to them, the same
 command will generate a SBOM manifest on-demand, which will take longer.

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -30,20 +30,21 @@ func downloadCmd(args []string) error {
 	}
 
 	var format string
+	var platform string
 	img := f.Arg(f.NArg() - 1)
 	if f.Arg(0) == "provenance" {
 		f.StringVar(&format, "format", "slsav0.2", "The format for the Provenance output. Supported values are slsav0.2 (default) and slsav1.")
+		f.StringVar(&platform, "platform", "linux/amd64", "The target platform for the container image. Most supported platforms are linux/amd64 and linux/arm64.")
 
 		err := f.Parse(args[1:])
 		if err != nil {
 			return err
 		}
 
-		return provenanceCmd(img, format)
+		return provenanceCmd(img, format, platform)
 	}
 
 	if f.Arg(0) == "sbom" {
-		var platform string
 		f.StringVar(&format, "format", "spdxjson", "The format for the SBOM output. Supported values are spdxjson (default) and cyclonedxjson.")
 		f.StringVar(&platform, "platform", "linux/amd64", "The target platform for the container image. Most supported platforms are linux/amd64 and linux/arm64.")
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -43,14 +43,16 @@ func downloadCmd(args []string) error {
 	}
 
 	if f.Arg(0) == "sbom" {
+		var platform string
 		f.StringVar(&format, "format", "spdxjson", "The format for the SBOM output. Supported values are spdxjson (default) and cyclonedxjson.")
+		f.StringVar(&platform, "platform", "linux/amd64", "The target platform for the container image. Most supported platforms are linux/amd64 and linux/arm64.")
 
 		err := f.Parse(args[1:])
 		if err != nil {
 			return err
 		}
 
-		return sbomCmd(img, format)
+		return sbomCmd(img, format, platform)
 	}
 
 	showDownloadUsage()

--- a/cmd/provenance.go
+++ b/cmd/provenance.go
@@ -6,48 +6,62 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
+	v02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/rancherlabs/slsactl/internal/provenance"
 )
 
-func provenanceCmd(img, format string) error {
+func provenanceCmd(img, format, platform string) error {
+	var data bytes.Buffer
+	err := writeContent(img, "{{json .Provenance}}", &data)
+	if err != nil {
+		return err
+	}
+
+	var buildKit provenance.BuildKitProvenance02
+	err = json.Unmarshal(data.Bytes(), &buildKit)
+	if err != nil {
+		return fmt.Errorf("cannot parse v0.2 provenance: %w", err)
+	}
+
+	var predicate *v02.ProvenancePredicate
+	if strings.EqualFold(platform, "linux/amd64") {
+		if buildKit.LinuxAmd64 != nil {
+			predicate = &buildKit.LinuxAmd64.SLSA
+		}
+	} else if strings.EqualFold(platform, "linux/arm64") {
+		if buildKit.LinuxArm64 != nil {
+			predicate = &buildKit.LinuxArm64.SLSA
+		}
+	} else {
+		return fmt.Errorf("platform not supported: %q", platform)
+	}
+
+	if predicate == nil {
+		return fmt.Errorf("provenance information not found for platform %q", platform)
+	}
+
 	switch format {
 	case "slsav0.2":
-		return writeContent(img, "{{json .Provenance}}", os.Stdout)
+		err = print(os.Stdout, predicate)
 	case "slsav1":
-		var buf bytes.Buffer
-		err := writeContent(img, "{{json .Provenance}}", &buf)
-		if err != nil {
-			return err
-		}
+		provV1 := provenance.ConvertV02ToV1(*predicate)
+		err = print(os.Stdout, provV1)
 
-		convert(buf.Bytes(), os.Stdout)
-		return nil
+	default:
+		return fmt.Errorf("invalid format %q: supported values are slsav0.2 or slsav1", format)
 	}
 
-	return fmt.Errorf("invalid format %q: supported values are slsav0.2 or slsav1", format)
+	return err
 }
 
-func convert(data []byte, w io.Writer) {
-	var buildKit provenance.BuildKitProvenance02
-	err := json.Unmarshal(data, &buildKit)
+func print(w io.Writer, v interface{}) error {
+	outData, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		fmt.Printf("Error parsing v0.2 provenance: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to marshal v1 provenance: %w", err)
 	}
 
-	if buildKit.LinuxAmd64 == nil {
-		fmt.Println("Error: image does not contain provenance information")
-		os.Exit(5)
-	}
-
-	provV1 := provenance.ConvertV02ToV1(buildKit.LinuxAmd64.SLSA)
-
-	outData, err := json.MarshalIndent(provV1, "", "  ")
-	if err != nil {
-		fmt.Printf("Error marshaling v1 provenance: %v\n", err)
-		os.Exit(1)
-	}
-
-	io.WriteString(w, string(outData))
+	_, err = fmt.Fprintln(w, string(outData))
+	return err
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ var (
 
 Available commands:
   download:   Download artefacts from container image
-  verify: 	  Verifies the container image's signature
+  verify:     Verifies the container image's signature
   version:    Shows %[1]s version and build information
 
 `

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ var (
 
 Available commands:
   download:   Download artefacts from container image
+  verify: 	  Verifies the container image's signature
   version:    Shows %[1]s version and build information
 
 `

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -36,27 +36,28 @@ func sbomCmd(img, outformat, platform string) error {
 
 	var spdx json.RawMessage
 	if strings.EqualFold(platform, "linux/amd64") {
-		if data.LinuxAmd64 == nil || data.LinuxAmd64.SPDX == nil {
-			return fmt.Errorf("no spdx found for %q", platform)
+		if data.LinuxAmd64 != nil {
+			spdx = data.LinuxAmd64.SPDX
 		}
 
-		spdx = data.LinuxAmd64.SPDX
 	} else if strings.EqualFold(platform, "linux/arm64") {
-		if data.LinuxArm64 == nil || data.LinuxArm64.SPDX == nil {
-			return fmt.Errorf("no spdx found for %q", platform)
+		if data.LinuxArm64 != nil {
+			spdx = data.LinuxArm64.SPDX
 		}
-		spdx = data.LinuxArm64.SPDX
 	} else {
 		return fmt.Errorf("platform not supported: %q", platform)
 	}
 
-	m, err := spdx.MarshalJSON()
-	if len(m) > 4 && err == nil {
-		buf.Reset()
-		buf.ReadFrom(bytes.NewBuffer(m))
+	if len(spdx) != 0 {
+		m, err := spdx.MarshalJSON()
+		if len(m) > 4 && err == nil {
+			buf.Reset()
+			buf.ReadFrom(bytes.NewBuffer(m))
+		}
 	}
 
 	if buf.Len() < 10 {
+		buf.Reset()
 		// The image does not contain a SBOM layer, generates SBOM on demand.
 		err = sbom.Generate(img, outformat, &buf)
 		if err != nil {

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/rancherlabs/slsactl/internal/sbom"
 )
 
-func sbomCmd(img, outformat string) error {
+func sbomCmd(img, outformat, platform string) error {
 	var buf bytes.Buffer
 	err := writeContent(img, "{{json .SBOM}}", &buf)
 	if err != nil {
@@ -29,16 +30,30 @@ func sbomCmd(img, outformat string) error {
 	var data sbom.BuildKitSBOM
 	err = json.Unmarshal(buf.Bytes(), &data)
 	if err != nil {
-		fmt.Println("Error to unmarshal SBOM: %w\n", err)
+		fmt.Println("Error cannot unmarshal SBOM: %w\n", err)
 		os.Exit(6)
 	}
 
-	if data.LinuxAmd64 != nil && data.LinuxAmd64.SPDX != nil {
-		m, err := data.LinuxAmd64.SPDX.MarshalJSON()
-		if len(m) > 0 && err == nil {
-			buf.Reset()
-			buf.ReadFrom(bytes.NewBuffer(m))
+	var spdx json.RawMessage
+	if strings.EqualFold(platform, "linux/amd64") {
+		if data.LinuxAmd64 == nil || data.LinuxAmd64.SPDX == nil {
+			return fmt.Errorf("no spdx found for %q", platform)
 		}
+
+		spdx = data.LinuxAmd64.SPDX
+	} else if strings.EqualFold(platform, "linux/arm64") {
+		if data.LinuxArm64 == nil || data.LinuxArm64.SPDX == nil {
+			return fmt.Errorf("no spdx found for %q", platform)
+		}
+		spdx = data.LinuxArm64.SPDX
+	} else {
+		return fmt.Errorf("platform not supported: %q", platform)
+	}
+
+	m, err := spdx.MarshalJSON()
+	if len(m) > 4 && err == nil {
+		buf.Reset()
+		buf.ReadFrom(bytes.NewBuffer(m))
 	}
 
 	if buf.Len() < 10 {

--- a/internal/provenance/provenance.go
+++ b/internal/provenance/provenance.go
@@ -24,7 +24,7 @@ type ArchProvenanceV1 struct {
 }
 
 func ConvertV02ToV1(v02Prov v02.ProvenancePredicate) v1.ProvenancePredicate {
-	return v1.ProvenancePredicate{
+	prov := v1.ProvenancePredicate{
 		BuildDefinition: v1.ProvenanceBuildDefinition{
 			BuildType:          v02Prov.BuildType,
 			ExternalParameters: v02Prov.Invocation.Parameters,
@@ -35,10 +35,23 @@ func ConvertV02ToV1(v02Prov v02.ProvenancePredicate) v1.ProvenancePredicate {
 				ID: v02Prov.Invocation.ConfigSource.URI,
 			},
 			BuildMetadata: v1.BuildMetadata{
-				StartedOn:  v02Prov.Metadata.BuildStartedOn,
-				FinishedOn: v02Prov.Metadata.BuildFinishedOn,
+				StartedOn:    v02Prov.Metadata.BuildStartedOn,
+				FinishedOn:   v02Prov.Metadata.BuildFinishedOn,
+				InvocationID: v02Prov.Metadata.BuildInvocationID,
 			},
 			Byproducts: []v1.ResourceDescriptor{},
 		},
 	}
+
+	deps := make([]v1.ResourceDescriptor, 0, len(v02Prov.Materials))
+	for _, m := range v02Prov.Materials {
+		deps = append(deps, v1.ResourceDescriptor{
+			URI:    m.URI,
+			Digest: m.Digest,
+		})
+	}
+
+	prov.BuildDefinition.ResolvedDependencies = deps
+
+	return prov
 }

--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -99,7 +99,10 @@ func ConvertToCyclonedxJson(reader io.Reader, writer io.Writer) error {
 		return fmt.Errorf("failed to decode SPDX JSON SBOM: %w", err)
 	}
 
-	enc, err := cyclonedxjson.NewFormatEncoderWithConfig(cyclonedxjson.DefaultEncoderConfig())
+	cfg := cyclonedxjson.DefaultEncoderConfig()
+	cfg.Pretty = true
+
+	enc, err := cyclonedxjson.NewFormatEncoderWithConfig(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create cyclonedxjson encoder: %w", err)
 	}


### PR DESCRIPTION
- Add `--platform` for both `sbom` and `provenance` to return platform specific data.
- Add resolved dependencies and invocationID information when converting provenance data from v0.2 to v1.