### PR TITLE
Add support for OBS signed images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           go-version: stable
 
-      - uses: anchore/sbom-action/download-syft@55dc4ee22412511ee8c3142cbea40418e6cec693 # v0.17.8
       - uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Run GoReleaser

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+  pull_request:
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,7 @@ name: Tests
 on:
   push:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test:
@@ -20,4 +19,21 @@ jobs:
     
     - run: make test
     - run: make verify
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - uses: ./actions/install-slsactl
     - run: make e2e
+
+  test-verify-action:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - uses: ./actions/verify
+      with:
+        image: ghcr.io/kubewarden/policy-server:v1.19.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,3 +20,4 @@ jobs:
     
     - run: make test
     - run: make verify
+    - run: make e2e

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,12 +40,6 @@ source:
   enabled: true
   name_template: '{{ .ProjectName }}_{{ .Version }}_source'
 
-sboms:
-  - id: source
-    artifacts: source
-    documents:
-      - '{{ .ProjectName }}_{{ .Version }}_sbom.spdx.json'
-
 release:
   extra_files:
     - glob: ./**/*.bundle

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ build:
 test:
 	go test -race ./...
 
+e2e:
+	./hack/e2e.sh
+
 verify: verify-lint verify-dirty ## Run verification checks.
 
 verify-lint: $(GOLANGCI)

--- a/actions/install-slsactl/action.yml
+++ b/actions/install-slsactl/action.yml
@@ -1,0 +1,32 @@
+# This GitHub action install the slsactl CLI, making it available for
+# other steps within an GitHub workflow to refer to it.
+#
+# Reference usage:
+#    steps:
+#      ...
+#      - uses: rancherlabs/slsactl/actions/install-slsactl@main
+#        with:
+#          version: latest
+
+name: install-slsactl
+
+inputs:
+  version:
+    description: |
+      The slsactl version to be installed.
+    required: false
+    default: latest
+    type: string
+
+runs:
+  using: composite
+
+  steps:
+  - uses: actions/setup-go@v5
+    with:
+      go-version: 'stable'
+
+  - name: Install slsactl
+    shell:
+    run: |
+      go install github.com/rancherlabs/slsactl@${{ inputs.version }}

--- a/actions/verify/action.yml
+++ b/actions/verify/action.yml
@@ -29,10 +29,7 @@ runs:
     with:
       go-version: 'stable'
 
-  - name: Install slsactl
-    shell:
-    run: |
-      go install github.com/rancherlabs/slsactl@latest
+  - uses: ./actions/install-slsactl
 
   - name: Verify image
     shell: bash

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eox pipefail
+
+IMAGE=${IMAGE:-ghcr.io/kubewarden/policy-server:v1.19.0}
+
+slsactl verify "${IMAGE}"
+slsactl download provenance "${IMAGE}"
+slsactl download provenance --format=slsav1 "${IMAGE}"
+slsactl download sbom "${IMAGE}"
+slsactl download sbom -format cyclonedxjson "${IMAGE}"
+slsactl version

--- a/pkg/verify/mapping.go
+++ b/pkg/verify/mapping.go
@@ -1,5 +1,10 @@
 package verify
 
+import (
+	"fmt"
+	"strings"
+)
+
 // imageRepo holds the mappings between container image and source code repositories.
 var imageRepo = map[string]string{
 	"rancher/rke2-runtime":                    "rancher/rke2",
@@ -19,4 +24,26 @@ var imageRepo = map[string]string{
 	"rancher/hardened-cni-plugins":            "rancher/image-build-cni-plugins",
 	"rancher/nginx-ingress-controller":        "rancher/ingress-nginx",
 	"rancher/rancher":                         "rancher/rancher-prime",
+}
+
+var obs = map[string]struct{}{
+	"rancher/elemental-operator":            {},
+	"rancher/seedimage-builder":             {},
+	"rancher/elemental-channel/sl-micro":    {},
+	"rancher/elemental-operator-crds-chart": {},
+	"rancher/elemental-operator-chart":      {},
+}
+
+func obsSigned(image string) bool {
+	bef, after, _ := strings.Cut(image, "/")
+	if strings.Contains(bef, ".") {
+		image = after
+	}
+
+	bef, _, _ = strings.Cut(image, ":")
+	image = bef
+	fmt.Println(image)
+
+	_, ok := obs[image]
+	return ok
 }

--- a/pkg/verify/verify_test.go
+++ b/pkg/verify/verify_test.go
@@ -93,7 +93,6 @@ func TestCertificateIdentity(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.image, func(t *testing.T) {
 			t.Parallel()
 
@@ -107,5 +106,28 @@ func TestCertificateIdentity(t *testing.T) {
 				assert.ErrorContains(t, err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestObsSigned(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		image string
+		want  bool
+	}{
+		{image: "rancher/elemental-operator", want: true},
+		{image: "rancher/seedimage-builder", want: true},
+		{image: "rancher/elemental-channel/sl-micro", want: true},
+		{image: "rancher/elemental-operator-crds-chart", want: true},
+		{image: "rancher/elemental-operator-chart", want: true},
+		{image: "rancher/rancher"},
+		{image: "ghcr.io/kubewarden/policy-server"},
+		{image: "fuzz/bar"},
+	}
+
+	for _, tc := range tests {
+		got := obsSigned(tc.image)
+		assert.Equal(t, tc.want, got)
 	}
 }


### PR DESCRIPTION
- OBS images can now be verified using the same naming convention as for cosign keyless-signed images.
- The SBOM generation for binaries is temporarily disabled, and will be reverted later on.
- Added E2E tests to avoid breaking the existing cli UX.