### PR TITLE
Verify images built for upstream Cluster API projects

### DIFF
--- a/pkg/verify/mapping.go
+++ b/pkg/verify/mapping.go
@@ -47,3 +47,13 @@ func obsSigned(image string) bool {
 	_, ok := obs[image]
 	return ok
 }
+
+var upstreamImageRepo = map[string]string{
+	"rancher/cluster-api-controller":             "https://github.com/rancher/clusterapi-forks/.github/workflows/core.yaml@refs/heads/main",
+	"rancher/cluster-api-aws-controller":         "https://github.com/rancher/clusterapi-forks/.github/workflows/aws.yaml@refs/heads/main",
+	"rancher/cluster-api-azure-controller":       "https://github.com/rancher/clusterapi-forks/.github/workflows/azure.yaml@refs/heads/main",
+	"rancher/cluster-api-gcp-controller":         "https://github.com/rancher/clusterapi-forks/.github/workflows/gcp.yaml@refs/heads/main",
+	"rancher/cluster-api-vsphere-controller":     "https://github.com/rancher/clusterapi-forks/.github/workflows/vsphere.yaml@refs/heads/main",
+	"rancher/cluster-api-metal3-controller":      "https://github.com/rancher/clusterapi-forks/.github/workflows/metal3.yaml@refs/heads/main",
+	"rancher/cluster-api-metal3-ipam-controller": "https://github.com/rancher/clusterapi-forks/.github/workflows/metal3-ipam.yaml@refs/heads/main",
+}

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -127,10 +127,12 @@ func certIdentity(imageName string) (string, error) {
 
 	repo = overrideRepo(repo)
 
-	indentity := fmt.Sprintf(
-		"https://github.com/%s/.github/workflows/release.yml@refs/tags/%s", repo, ref)
+	// Check if the image is an upstream image and has a different cert identity.
+	if identity, isUpstreamRepo := upstreamImageRepo[repo]; isUpstreamRepo {
+		return identity, nil
+	}
 
-	return indentity, nil
+	return fmt.Sprintf("https://github.com/%s/.github/workflows/release.yml@refs/tags/%s", repo, ref), nil
 }
 
 func overrideRepo(repo string) string {


### PR DESCRIPTION
This PR adds verification for images that are built for upstream projects, currently only cluster-api is support but there is an option to add more later. The repository we're building images from https://github.com/rancher/clusterapi-forks/tree/main/.github/workflows