### PR TITLE
Improve `install-slsactl` action

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -1,0 +1,38 @@
+name: Test Actions
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  test-install-action:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, windows-latest]
+    
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - uses: ./actions/install-slsactl
+    - run: slsactl version
+      shell: bash
+
+  test-verify-action:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, windows-latest]
+    
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - uses: ./actions/verify
+      with:
+        image: ghcr.io/kubewarden/policy-server:v1.19.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+  pull_request:
+  workflow_dispatch:
 
 permissions: {}
 
@@ -28,12 +30,3 @@ jobs:
 
     - uses: ./actions/install-slsactl
     - run: make e2e
-
-  test-verify-action:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - uses: ./actions/verify
-      with:
-        image: ghcr.io/kubewarden/policy-server:v1.19.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,8 +7,9 @@ builds:
     flags:
     - -trimpath
     ldflags:
+      - -extldflags
       - -s -w
-      - -X github.com/slsactl/cmd/cmd.version={{.Version}}
+      - -X github.com/rancherlabs/slsactl/cmd.version={{ .Version }}
     goos:
       - linux
       - windows

--- a/actions/install-slsactl/action.yml
+++ b/actions/install-slsactl/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: |
       The slsactl version to be installed.
     required: false
-    default: v0.0.4
+    default: latest
     type: string
 
 runs:
@@ -41,6 +41,13 @@ runs:
     if: runner.os == 'Linux'
     shell: bash
     run: |
+      if [[ "${VERSION}" == "latest" ]]; then
+        echo 'Checking what the latest version is'
+        VERSION=$(curl -s 'https://api.github.com/repos/rancherlabs/slsactl/releases/latest' | jq -r '.tag_name')
+        
+        echo "Using last tag ${VERSION} as version"
+      fi
+
       echo "Downloading checksum file and signatures for release ${VERSION}"
       curl -LO "https://${REPO}/releases/download/${VERSION}/slsactl_${VERSION#v}_checksums.txt.pem"
       curl -LO "https://${REPO}/releases/download/${VERSION}/slsactl_${VERSION#v}_checksums.txt.sig"

--- a/actions/install-slsactl/action.yml
+++ b/actions/install-slsactl/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: |
       The slsactl version to be installed.
     required: false
-    default: latest
+    default: v0.0.4
     type: string
 
 runs:
@@ -23,10 +23,59 @@ runs:
 
   steps:
   - uses: actions/setup-go@v5
+    if: runner.os == 'Windows'
     with:
       go-version: 'stable'
 
-  - name: Install slsactl
-    shell:
+  - name: Install slsactl with go install
+    if: runner.os == 'Windows'
+    shell: pwsh
     run: |
       go install github.com/rancherlabs/slsactl@${{ inputs.version }}
+
+  - name: Install Cosign
+    uses: sigstore/cosign-installer@v3.5.0
+    if: runner.os == 'Linux'
+
+  - name: Install slsactl from gh release
+    if: runner.os == 'Linux'
+    shell: bash
+    run: |
+      echo "Downloading checksum file and signatures for release ${VERSION}"
+      curl -LO "https://${REPO}/releases/download/${VERSION}/slsactl_${VERSION#v}_checksums.txt.pem"
+      curl -LO "https://${REPO}/releases/download/${VERSION}/slsactl_${VERSION#v}_checksums.txt.sig"
+      curl -LO "https://${REPO}/releases/download/${VERSION}/slsactl_${VERSION#v}_checksums.txt"
+
+      cosign verify-blob \
+          --certificate-identity "https://${REPO}/.github/workflows/release.yml@refs/tags/${VERSION}" \
+          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+          --certificate "slsactl_${VERSION#v}_checksums.txt.pem" \
+          --signature "slsactl_${VERSION#v}_checksums.txt.sig" "slsactl_${VERSION#v}_checksums.txt"
+
+      OS="linux"
+      if [[ ${RUNNER_OS} != "Linux" ]]; then
+          echo "Unsupported OS: ${RUNNER_OS}"
+          exit 1
+      fi
+
+      ARCH=""
+      if [[ $(uname -m) == "x86_64" ]]; then
+          ARCH=amd64
+      fi
+      if [[ $(uname -m) == "aarch64" ]]; then
+          ARCH=arm64
+      fi
+
+      echo "Installing slsactl_${VERSION#v}_${OS}_${ARCH}"
+      curl -LO "https://${REPO}/releases/download/${VERSION}/slsactl_${VERSION#v}_${OS}_${ARCH}"
+      chmod +x "slsactl_${VERSION#v}_${OS}_${ARCH}"
+      sudo mv "slsactl_${VERSION#v}_${OS}_${ARCH}" /usr/local/bin/slsactl
+    env:
+      VERSION: ${{ inputs.version }}
+      REPO: github.com/rancherlabs/slsactl
+
+  - name: Print version
+    shell: bash
+    run: |
+      echo "slsactl installed:"
+      slsactl version

--- a/actions/install-slsactl/action.yml
+++ b/actions/install-slsactl/action.yml
@@ -73,10 +73,14 @@ runs:
           ARCH=arm64
       fi
 
-      echo "Installing slsactl_${VERSION#v}_${OS}_${ARCH}"
-      curl -LO "https://${REPO}/releases/download/${VERSION}/slsactl_${VERSION#v}_${OS}_${ARCH}"
-      chmod +x "slsactl_${VERSION#v}_${OS}_${ARCH}"
-      sudo mv "slsactl_${VERSION#v}_${OS}_${ARCH}" /usr/local/bin/slsactl
+      FILE="slsactl_${VERSION#v}_${OS}_${ARCH}"
+
+      echo "Installing ${FILE}"
+      curl -LO "https://${REPO}/releases/download/${VERSION}/${FILE}"
+      grep "${FILE}" "slsactl_${VERSION#v}_checksums.txt" | sha256sum -c
+
+      chmod +x "${FILE}"
+      sudo mv "${FILE}" /usr/local/bin/slsactl
     env:
       VERSION: ${{ inputs.version }}
       REPO: github.com/rancherlabs/slsactl


### PR DESCRIPTION
Key improvements for Linux:
- Install from release binaries (which is faster than `go install`).
- Validate signature and binary checksum before using it.
- `latest` installs last released version.