### PR TITLE
Cleanup checksum files

### DIFF
--- a/actions/install-slsactl/action.yml
+++ b/actions/install-slsactl/action.yml
@@ -90,8 +90,10 @@ runs:
 
       if sudo -l &> /dev/null; then
         sudo mv "${FILE}" /usr/local/bin/slsactl
+        sudo rm -f "slsactl_${VERSION#v}_checksums.txt" "slsactl_${VERSION#v}_checksums.txt.pem" "slsactl_${VERSION#v}_checksums.txt.sig"
       else
         mv "${FILE}" /usr/local/bin/slsactl
+        rm -f "slsactl_${VERSION#v}_checksums.txt" "slsactl_${VERSION#v}_checksums.txt.pem" "slsactl_${VERSION#v}_checksums.txt.sig"
       fi
     env:
       VERSION: ${{ inputs.version }}


### PR DESCRIPTION
When installing `slsactl`, additional checksum files are also being downloaded in order to verify the binary being installed. For `v0.0.6` these files are:
- slsactl_0.0.6_checksums.txt
-  slsactl_0.0.6_checksums.txt.pem
- slsactl_0.0.6_checksums.txt.sig

If after installing `slsactl`,`goreleaser` gets invoked, it will fail with a [git is in a dirty state](https://goreleaser.com/errors/dirty/) error, because the files above are still left in the working directory.

This PR adds a command to remove these files, once they are used to verify the binary.

Error example: https://github.com/rancher/aks-operator/actions/runs/12390797726/job/34586585694#step:5:78 