### PR TITLE
verify: Add mapping for neuvector images

### DIFF
--- a/pkg/verify/mapping.go
+++ b/pkg/verify/mapping.go
@@ -24,6 +24,14 @@ var imageRepo = map[string]string{
 	"rancher/hardened-cni-plugins":            "rancher/image-build-cni-plugins",
 	"rancher/nginx-ingress-controller":        "rancher/ingress-nginx",
 	"rancher/rancher":                         "rancher/rancher-prime",
+	"rancher/neuvector-manager":               "neuvector/manager",
+	"rancher/neuvector-controller":            "neuvector/neuvector",
+	"rancher/neuvector-enforcer":              "neuvector/neuvector",
+	"rancher/neuvector-scanner":               "neuvector/scanner",
+	"rancher/neuvector-prometheus-exporter":   "neuvector/prometheus-exporter",
+	"rancher/neuvector-registry-adapter":      "neuvector/registry-adapter",
+	"rancher/neuvector-updater":               "neuvector/updater",
+	"rancher/neuvector-compliance-config":     "neuvector/compliance-config",
 }
 
 var obs = map[string]struct{}{

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -119,6 +119,12 @@ func certIdentity(imageName string) (string, error) {
 	if strings.Contains(imageName, "rke2") {
 		ref = strings.Replace(d[1], "-rke2", "&#43;rke2", 1)
 	}
+
+	// neuvector images don't have "v" prefix like its Git tags
+	if strings.Contains(imageName, "neuvector") {
+		ref = "v" + ref
+	}
+
 	for _, suffix := range archSuffixes {
 		if strings.HasSuffix(ref, suffix) {
 			ref = strings.TrimSuffix(ref, suffix)


### PR DESCRIPTION
## Purpose

Add image mapping for neuvector images, so they can be verified with slsactl.

## Tests performed:
```
./build/bin/slsactl verify registry.rancher.com/rancher/neuvector-controller:5.4.2
./build/bin/slsactl verify registry.rancher.com/rancher/neuvector-manager:5.4.2
./build/bin/slsactl verify registry.rancher.com/rancher/neuvector-enforcer:5.4.2
./build/bin/slsactl verify registry.rancher.com/rancher/neuvector-scanner:3.682
./build/bin/slsactl verify registry.rancher.com/rancher/neuvector-prometheus-exporter:1.0.1
./build/bin/slsactl verify registry.rancher.com/rancher/neuvector-registry-adapter:0.1.4
./build/bin/slsactl verify registry.rancher.com/rancher/neuvector-updater:0.0.1
./build/bin/slsactl verify registry.rancher.com/rancher/neuvector-compliance-config:1.0.2
./build/bin/slsactl verify registry.rancher.com/rancher/cis-operator:v1.3.4
```