### PR TITLE
verify: support verifying mutable images

### DIFF
--- a/internal/cosign/cosign.go
+++ b/internal/cosign/cosign.go
@@ -1,0 +1,73 @@
+package cosign
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
+	v1 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
+	"github.com/rancherlabs/slsactl/internal/provenance"
+	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/fulcio/pkg/certificate"
+)
+
+const (
+	// builderID defines the builder ID when the provenance has been modified.
+	builderID = "https://github.com/rancherlabs/slsactl/tree/main/buildtypes/buildkit-gha/v1"
+)
+
+func GetCosignCertData(ctx context.Context, img string) (*v1.ProvenancePredicate, error) {
+	ref, err := name.ParseReference(img, name.StrictValidation)
+	if err != nil {
+		return nil, fmt.Errorf("failed strict validation (image name should be fully qualified): %w", err)
+	}
+
+	payloads, err := cosign.FetchSignaturesForReference(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch image signatures: %w", err)
+	}
+
+	if len(payloads) == 0 {
+		return nil, errors.New("no payloads found for image")
+	}
+
+	var inparams provenance.InternalParameters
+	var commitID, commitRef, repoURL string
+
+	for _, ext := range payloads[0].Cert.Extensions {
+		switch {
+		case ext.Id.Equal(certificate.OIDSourceRepositoryDigest):
+			certificate.ParseDERString(ext.Value, &commitID)
+		case ext.Id.Equal(certificate.OIDSourceRepositoryURI):
+			certificate.ParseDERString(ext.Value, &repoURL)
+		case ext.Id.Equal(certificate.OIDSourceRepositoryRef):
+			certificate.ParseDERString(ext.Value, &commitRef)
+		case ext.Id.Equal(certificate.OIDBuildTrigger):
+			certificate.ParseDERString(ext.Value, &inparams.Trigger)
+		case ext.Id.Equal(certificate.OIDRunInvocationURI):
+			certificate.ParseDERString(ext.Value, &inparams.InvocationUri)
+		}
+	}
+
+	override := &v1.ProvenancePredicate{}
+	override.BuildDefinition.InternalParameters = inparams
+	deps := []v1.ResourceDescriptor{
+		{
+			URI:    repoURL,
+			Digest: common.DigestSet{"gitCommit": commitID},
+		},
+	}
+
+	if commitRef != "" {
+		deps[0].Annotations = map[string]interface{}{
+			"ref": commitRef,
+		}
+	}
+
+	override.BuildDefinition.ResolvedDependencies = deps
+	override.RunDetails.Builder.ID = builderID
+
+	return override, nil
+}

--- a/pkg/verify/mapping.go
+++ b/pkg/verify/mapping.go
@@ -34,6 +34,10 @@ var imageRepo = map[string]string{
 	"rancher/neuvector-compliance-config":     "neuvector/compliance-config",
 }
 
+var mutableRepo = map[string]bool{
+	"rancher/neuvector-scanner:6": true,
+}
+
 var obs = map[string]struct{}{
 	"rancher/elemental-operator":            {},
 	"rancher/seedimage-builder":             {},

--- a/pkg/verify/verify_test.go
+++ b/pkg/verify/verify_test.go
@@ -90,13 +90,21 @@ func TestCertificateIdentity(t *testing.T) {
 			image: "rocker.local/foo/bar:v0.0.7-build12345",
 			want:  "https://github.com/foo/bar/.github/workflows/release.yml@refs/tags/v0.0.7-build12345",
 		},
+		{
+			image: "rancher/neuvector-controller:5.4.2",
+			want:  "https://github.com/neuvector/neuvector/.github/workflows/release.yml@refs/tags/v5.4.2",
+		},
+		{
+			image: "rancher/neuvector-scanner:3.685",
+			want:  "https://github.com/neuvector/scanner/.github/workflows/release.yml@refs/tags/v3.685",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.image, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := certIdentity(tc.image)
+			got, err := getCertIdentity(tc.image)
 
 			assert.Equal(t, tc.want, got)
 


### PR DESCRIPTION
## Changes

1. Move `cosignCertData()` to internal/cosign and rename as `GetCosignCertData()`.
2. Move image path parsing logic to `getImageRepoRef()`.
3. Add `getMutableCertIdentity()` to handle mutable images.