### PR TITLE
verify: Add mapping for additional fleet image

### DIFF
--- a/pkg/verify/mapping.go
+++ b/pkg/verify/mapping.go
@@ -7,6 +7,7 @@ import (
 
 // imageRepo holds the mappings between container image and source code repositories.
 var imageRepo = map[string]string{
+	"rancher/fleet-agent":                     "rancher/fleet",
 	"rancher/rke2-runtime":                    "rancher/rke2",
 	"rancher/rke2-cloud-provider":             "rancher/image-build-rke2-cloud-provider",
 	"rancher/hardened-addon-resizer":          "rancher/image-build-addon-resizer",


### PR DESCRIPTION
We have two docker images, one matching the default mapping but our second image `fleet-agent` does not.