### PR TITLE
sbom: Add support for `windows/amd64`

### DIFF
--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -39,6 +39,8 @@ func sbomCmd(img, outformat, platform string) error {
 		spdx = data.LinuxAmd64.SPDX
 	} else if strings.EqualFold(platform, "linux/arm64") && data.LinuxArm64 != nil {
 		spdx = data.LinuxArm64.SPDX
+	} else if strings.EqualFold(platform, "windows/amd64") && data.WindowsAmd64 != nil {
+		spdx = data.WindowsAmd64.SPDX
 	} else if data.SPDX != nil {
 		spdx = *data.SPDX
 	} else {

--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -18,9 +18,10 @@ import (
 )
 
 type BuildKitSBOM struct {
-	LinuxAmd64 *archSBOM        `json:"linux/amd64,omitempty"`
-	LinuxArm64 *archSBOM        `json:"linux/arm64,omitempty"`
-	SPDX       *json.RawMessage `json:"SPDX,omitempty"`
+	LinuxAmd64   *archSBOM        `json:"linux/amd64,omitempty"`
+	LinuxArm64   *archSBOM        `json:"linux/arm64,omitempty"`
+	WindowsAmd64 *archSBOM        `json:"windows/amd64,omitempty"`
+	SPDX         *json.RawMessage `json:"SPDX,omitempty"`
 }
 
 type archSBOM struct {


### PR DESCRIPTION
Part of the ecosystem supports multi-platform images targeting `windows/amd64` this change adds support for it when extracting SBOMs.

This was tested against `rancher/rke2-runtime`.