### PR TITLE
Fix verification for hardened kubernetes images

### DIFF
--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -170,7 +170,7 @@ func getCertIdentity(imageName string) (string, error) {
 
 	// RKE2 images have container image tags <VERSION>-rke2r1 which are
 	// generated from Git tags <VERSION>+rke2r1.
-	if strings.Contains(imageName, "rke2") {
+	if strings.HasPrefix(repo, "rancher/rke2") {
 		ref = strings.Replace(ref, "-rke2", "&#43;rke2", 1)
 	}
 

--- a/pkg/verify/verify_test.go
+++ b/pkg/verify/verify_test.go
@@ -15,12 +15,16 @@ func TestCertificateIdentity(t *testing.T) {
 		wantErr string
 	}{
 		{
-			image: "foo/bar:v0.0.7",
-			want:  "https://github.com/foo/bar/.github/workflows/release.yml@refs/tags/v0.0.7",
+			image: "rancher/rke2:v0.0.7",
+			want:  "https://github.com/rancher/rke2/.github/workflows/release.yml@refs/tags/v0.0.7",
 		},
 		{
-			image: "foo/bar:v0.0.7-rke2foo2",
-			want:  "https://github.com/foo/bar/.github/workflows/release.yml@refs/tags/v0.0.7&#43;rke2foo2",
+			image: "rancher/rke2:v0.0.7-rke2foo2",
+			want:  "https://github.com/rancher/rke2/.github/workflows/release.yml@refs/tags/v0.0.7&#43;rke2foo2",
+		},
+		{
+			image: "rancher/hardened-kubernetes:v1.32.3-rke2r1-build20250312",
+			want:  "https://github.com/rancher/image-build-kubernetes/.github/workflows/release.yml@refs/tags/v1.32.3-rke2r1-build20250312",
 		},
 		{
 			image:   "",


### PR DESCRIPTION
The encoding across rke2 images are not consistent, therefore only apply the encoding for the images published from the `rancher/rke2` repository.