### PR TITLE
Add image / suffix mapping

### DIFF
--- a/pkg/verify/mapping.go
+++ b/pkg/verify/mapping.go
@@ -71,3 +71,10 @@ var upstreamImageRepo = map[string]string{
 	"rancher/cluster-api-metal3-controller":      "https://github.com/rancher/clusterapi-forks/.github/workflows/metal3.yaml@refs/heads/main",
 	"rancher/cluster-api-metal3-ipam-controller": "https://github.com/rancher/clusterapi-forks/.github/workflows/metal3-ipam.yaml@refs/heads/main",
 }
+
+// imageSuffixes holds a mapping between image name and the ref suffixes
+// they may have which will need to be trimmed before defining the expected
+// subject identity.
+var imageSuffixes = map[string][]string{
+	"rancher/hardened-multus-cni": {"-arch"},
+}

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -179,10 +179,13 @@ func getCertIdentity(imageName string) (string, error) {
 		ref = "v" + ref
 	}
 
-	for _, suffix := range archSuffixes {
-		if strings.HasSuffix(ref, suffix) {
-			ref = strings.TrimSuffix(ref, suffix)
-		}
+	suffixes := archSuffixes
+	if s, ok := imageSuffixes[repo]; ok {
+		suffixes = append(suffixes, s...)
+	}
+
+	for _, suffix := range suffixes {
+		ref = strings.TrimSuffix(ref, suffix)
 	}
 
 	repo = overrideRepo(repo)

--- a/pkg/verify/verify_test.go
+++ b/pkg/verify/verify_test.go
@@ -23,6 +23,10 @@ func TestCertificateIdentity(t *testing.T) {
 			want:  "https://github.com/foo/bar/.github/workflows/release.yml@refs/tags/v0.0.7&#43;rke2foo2",
 		},
 		{
+			image: "rancher/hardened-multus-cni:v1.32.3-arch",
+			want:  "https://github.com/rancher/image-build-multus/.github/workflows/release.yml@refs/tags/v1.32.3",
+		},
+		{
 			image:   "",
 			wantErr: "invalid image name",
 		},


### PR DESCRIPTION
Some pipelines would use the same tag to generate different image tags. The code already trims arch-based suffixes. The new mapping allows for arbitrary suffixes.