### PR TITLE
Add experimental landlock support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/rancherlabs/slsactl/internal/landlock"
 )
 
 type command func(args []string) error
@@ -26,6 +28,8 @@ Available commands:
 )
 
 func Exec(args []string) {
+	landlock.EnforceOrDie()
+
 	if len(args) < 2 {
 		showUsage()
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/docker/cli v28.0.4+incompatible
 	github.com/google/go-containerregistry v0.20.3
 	github.com/in-toto/in-toto-golang v0.9.0
+	github.com/landlock-lsm/go-landlock v0.0.0-20250303204525-1544bccde3a3
 	github.com/sigstore/cosign/v2 v2.5.0
 	github.com/sigstore/fulcio v1.6.6
 	github.com/stretchr/testify v1.10.0
@@ -402,6 +403,7 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
+	kernel.org/pub/linux/libs/security/libcap/psx v1.2.73 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/release-utils v0.11.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -900,6 +900,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/landlock-lsm/go-landlock v0.0.0-20250303204525-1544bccde3a3 h1:zcMi8R8vP0WrrXlFMNUBpDy/ydo3sTnCcUPowq1XmSc=
+github.com/landlock-lsm/go-landlock v0.0.0-20250303204525-1544bccde3a3/go.mod h1:RSub3ourNF8Hf+swvw49Catm3s7HVf4hzdFxDUnEzdA=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/letsencrypt/boulder v0.0.0-20240620165639-de9c06129bec h1:2tTW6cDth2TSgRbAhD7yjZzTQmcN25sDRPEeinR51yQ=
 github.com/letsencrypt/boulder v0.0.0-20240620165639-de9c06129bec/go.mod h1:TmwEoGCwIti7BCeJ9hescZgRtatxRE+A72pCoPfmcfk=
@@ -1955,6 +1957,8 @@ k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 h1:BZqlfIlq5YbRMFko6/PM7F
 k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340/go.mod h1:yD4MZYeKMBwQKVht279WycxKyM84kkAx2DPrTXaeb98=
 k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJJI8IUa1AmH/qa0=
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.73 h1:SEAEUiPVylTD4vqqi+vtGkSnXeP2FcRO3FoZB1MklMw=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.73/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
 modernc.org/libc v1.62.1 h1:s0+fv5E3FymN8eJVmnk0llBe6rOxCu/DEU+XygRbS8s=
 modernc.org/libc v1.62.1/go.mod h1:iXhATfJQLjG3NWy56a6WVU73lWOcdYVxsvwCgoPljuo=
 modernc.org/mathutil v1.7.1 h1:GCZVGXdaN8gTqB1Mf/usp1Y/hSqgI2vAGGP4jZMCxOU=

--- a/internal/landlock/landlock.go
+++ b/internal/landlock/landlock.go
@@ -1,0 +1,56 @@
+package landlock
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/landlock-lsm/go-landlock/landlock"
+)
+
+// EnforceOrDie checks where or not to enforce the landlock policy, and if so,
+// apply it. Any error will result in os.Exit.
+func EnforceOrDie() {
+	val, ok := os.LookupEnv("LANDLOCK_MODE")
+	if !ok {
+		return
+	}
+
+	cfg := landlock.V5
+
+	switch {
+	case strings.EqualFold(val, "on"):
+		slog.Debug("landlock enabled")
+	case strings.EqualFold(val, "besteffort"):
+		cfg = cfg.BestEffort()
+		slog.Debug("landlock set to best effort")
+	default:
+		slog.Debug("landlock disabled")
+		return
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Printf("failed to get user home dir: %v", err)
+		os.Exit(1)
+	}
+
+	// We can't really restrict the network access at present
+	err = cfg.RestrictPaths(
+		landlock.RWDirs(filepath.Join(home, ".sigstore")), // Sigstore TUF DB.
+		landlock.RODirs(
+			"/proc/self",
+		),
+		landlock.ROFiles(
+			"/etc/resolv.conf",                         // DNS resolution.
+			"/etc/ssl/ca-bundle.pem",                   // Root CA bundles to establish TLS.
+			filepath.Join(home, ".docker/config.json"), // Docker config to access OCI/registries.
+		),
+	)
+	if err != nil {
+		fmt.Printf("failed to enforce landlock policies (requires Linux 5.13+): %v", err)
+		os.Exit(2)
+	}
+}

--- a/internal/landlock/landlock.go
+++ b/internal/landlock/landlock.go
@@ -10,7 +10,7 @@ import (
 	"github.com/landlock-lsm/go-landlock/landlock"
 )
 
-// EnforceOrDie checks where or not to enforce the landlock policy, and if so,
+// EnforceOrDie checks whether or not to enforce the landlock policy, and if so,
 // apply it. Any error will result in os.Exit.
 func EnforceOrDie() {
 	val, ok := os.LookupEnv("LANDLOCK_MODE")


### PR DESCRIPTION
Add support for landlock enforcement, which can be opted in by setting the environment variable `LANDLOCK_MODE`.

Setting it to `ON` enforces it. If the kernel does not support it, the execution will fail. For best effort use `besteffort`, which results in enforcement whenever the feature is available.

More information on landlock can be found:
https://www.kernel.org/doc/html/latest/userspace-api/landlock.html