### PR TITLE
Support new tags for rke2-runtime

### DIFF
--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -169,9 +169,10 @@ func getCertIdentity(imageName string) (string, error) {
 	}
 
 	// RKE2 images have container image tags <VERSION>-rke2r1 which are
-	// generated from Git tags <VERSION>+rke2r1.
+	// generated from Git tags <VERSION>+rke2r1. Around version v1.33.0,
+	// the &#43; was replaced with +.
 	if strings.HasPrefix(repo, "rancher/rke2") {
-		ref = strings.Replace(ref, "-rke2", "&#43;rke2", 1)
+		ref = strings.Replace(ref, "-rke2", "(\\+|&#43;)rke2", 1)
 	}
 
 	// neuvector images don't have "v" prefix like its Git tags

--- a/pkg/verify/verify_test.go
+++ b/pkg/verify/verify_test.go
@@ -20,7 +20,7 @@ func TestCertificateIdentity(t *testing.T) {
 		},
 		{
 			image: "rancher/rke2:v0.0.7-rke2foo2",
-			want:  "^https://github.com/rancher/rke2/.github/workflows/release.(yml|yaml)@refs/tags/v0.0.7&#43;rke2foo2$",
+			want:  "^https://github.com/rancher/rke2/.github/workflows/release.(yml|yaml)@refs/tags/v0.0.7(\\+|&#43;)rke2foo2$",
 		},
 		{
 			image: "rancher/hardened-kubernetes:v1.32.3-rke2r1-build20250312",


### PR DESCRIPTION
The tag names for `rancher/rke2-runtime` has change since `v1.33.0-rke2r1`, the change adds support to that version while maintaining support to the former format.