### PR TITLE
landlock: Grant permission for artefact handling

### DIFF
--- a/internal/landlock/landlock.go
+++ b/internal/landlock/landlock.go
@@ -38,7 +38,8 @@ func EnforceOrDie() {
 	}
 
 	rwDirs := []string{
-		filepath.Join(home, ".sigstore"), // Sigstore TUF DB.
+		filepath.Join(home, ".sigstore"),         // Sigstore TUF DB.
+		filepath.Join(home, ".docker", "buildx"), // Image artefacts handling.
 	}
 
 	cwd, err := os.Getwd()


### PR DESCRIPTION
When downloading artefacts from an image using Docker Buildx, `slsactl` requires write access to `~/.docker/buildx`. Without this change the command `slsactl download provenance` may fail with:

```
failed to run download: open /home/levi/.docker/buildx/.lock: permission denied
```