### PR TITLE
landlock: Allow ro access to `/var/lib/ca-certificates`

### DIFF
--- a/internal/landlock/landlock.go
+++ b/internal/landlock/landlock.go
@@ -56,6 +56,7 @@ func EnforceOrDie() {
 		landlock.RODirs(
 			"/proc/self",
 			"/etc/ssl",                     // Root CA bundles to establish TLS.
+			"/var/lib/ca-certificates",     // Root CA bundles to establish TLS.
 			filepath.Join(home, ".docker"), // Docker config to access OCI/registries.
 		),
 		landlock.ROFiles(


### PR DESCRIPTION
In some Linux distributions this is needed in addition of `/etc/ssl`.