### PR TITLE
download: Add support for Bundles

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,7 @@ func Exec(args []string) {
 		showUsage()
 	}
 
-	name := os.Args[1]
+	name := args[1]
 	cmd, ok := cmds[name]
 	if !ok {
 		showUsage()


### PR DESCRIPTION
Enables the `download` command to support the creation of `slsav1` format for images that have the new Bundle format, instead of the former `.sig` signatures.