### PR TITLE
landlock: Use stderr for errors

### DIFF
--- a/internal/landlock/landlock.go
+++ b/internal/landlock/landlock.go
@@ -64,7 +64,7 @@ func EnforceOrDie() {
 		),
 	)
 	if err != nil {
-		fmt.Printf("failed to enforce landlock policies (requires Linux 5.13+): %v\n", err)
+		fmt.Fprintf(os.Stderr, "failed to enforce landlock policies (requires Linux 5.13+): %v\n", err)
 		if val == "on" {
 			os.Exit(2)
 		}


### PR DESCRIPTION
The output of the non-fatal error from landlock into stdout can break the consumption of a command that otherwise has been successful.