### PR TITLE
product: Add the copy subcommand

### DIFF
--- a/cmd/product.go
+++ b/cmd/product.go
@@ -10,8 +10,8 @@ import (
 )
 
 const productf = `usage:
-    %[1]s product verify rancher-prime:v2.12.2
-    %[1]s product artifacts rancher-prime:v2.12.2
+    %[1]s product verify --registry <src_registry> rancher-prime:v2.12.2
+    %[1]s product copy --registry <src_registry> rancher-prime:v2.12.2 <target_registry>
 `
 
 func productCmd(args []string) error {
@@ -33,7 +33,21 @@ func productCmd(args []string) error {
 		return fmt.Errorf("invalid name version %q: format expected <name>:<version>", arg)
 	}
 
-	return product.Verify(registry, nameVer[0], nameVer[1], true, true)
+	switch args[0] {
+	case "verify":
+		return product.Verify(registry, nameVer[0], nameVer[1], true, true)
+	case "copy":
+		if f.NArg() != 2 {
+			showProductUsage()
+		}
+
+		targetRegistry := f.Arg(1)
+		return product.Copy(registry, nameVer[0], nameVer[1], targetRegistry)
+	default:
+		showProductUsage()
+	}
+
+	return nil
 }
 
 func showProductUsage() {

--- a/internal/imagelist/copier.go
+++ b/internal/imagelist/copier.go
@@ -1,0 +1,148 @@
+package imagelist
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+var externalImages = map[string]string{
+	"sig-storage/snapshot-controller":                        "registry.k8s.io/sig-storage/snapshot-controller",
+	"sig-storage/snapshot-validation-webhook":                "registry.k8s.io/sig-storage/snapshot-validation-webhook",
+	"rancher/mirrored-sig-storage-csi-node-driver-registrar": "registry.k8s.io/sig-storage/csi-node-driver-registrar",
+	"rancher/mirrored-sig-storage-csi-attacher":              "registry.k8s.io/sig-storage/csi-attacher",
+	"rancher/mirrored-longhornio-csi-attacher":               "registry.k8s.io/sig-storage/csi-attacher",
+	"rancher/mirrored-sig-storage-csi-provisioner":           "registry.k8s.io/sig-storage/csi-provisioner",
+	"rancher/mirrored-sig-storage-csi-resizer":               "registry.k8s.io/sig-storage/csi-resizer",
+	"rancher/mirrored-sig-storage-csi-snapshotter":           "registry.k8s.io/sig-storage/csi-snapshotter",
+	"rancher/mirrored-sig-storage-livenessprobe":             "registry.k8s.io/sig-storage/rancher/mirrored-sig-storage-livenessprobe",
+	"rancher/mirrored-sig-storage-snapshot-controller":       "registry.k8s.io/sig-storage/snapshot-controller",
+	"rancher/appco-redis":                                    "dp.apps.rancher.io/containers/redis",
+	"rancher/mirrored-cilium-cilium":                         "quay.io/cilium/cilium",
+	"rancher/mirrored-cilium-cilium-envoy":                   "quay.io/cilium/cilium-envoy",
+	"rancher/mirrored-cilium-clustermesh-apiserver":          "quay.io/cilium/clustermesh-apiserver",
+	"rancher/mirrored-cilium-hubble-relay":                   "quay.io/cilium/hubble-relay",
+	"rancher/mirrored-cilium-operator-aws":                   "quay.io/cilium/operator-aws",
+	"rancher/mirrored-cilium-operator-azure":                 "quay.io/cilium/operator-azure",
+	"rancher/mirrored-cilium-operator-generic":               "quay.io/cilium/operator-generic",
+	"rancher/mirrored-kube-logging-config-reloader":          "ghcr.io/kube-logging/config-reloader",
+	"rancher/mirrored-kube-logging-logging-operator":         "ghcr.io/kube-logging/logging-operator",
+	"rancher/mirrored-kube-state-metrics-kube-state-metrics": "registry.k8s.io/kube-state-metrics/kube-state-metrics",
+	"rancher/mirrored-elemental-operator":                    "registry.suse.com/rancher/elemental-operator",
+	"rancher/mirrored-elemental-seedimage-builder":           "registry.suse.com/rancher/seedimage-builder",
+	"rancher/mirrored-cluster-api-controller":                "registry.k8s.io/cluster-api/cluster-api-controller",
+}
+
+type imageCopier struct {
+	m            sync.Mutex
+	mirroredOnly bool
+}
+
+func (i *imageCopier) Copy(srcImg, dstRegistry string) Entry {
+	entry := Entry{
+		Image: srcImg,
+	}
+
+	if i.mirroredOnly && !strings.Contains(srcImg, "mirrored") {
+		entry.Error = errors.New("skipping non-mirrored image: " + srcImg)
+		return entry
+	}
+
+	ref, err := name.ParseReference(srcImg, name.WeakValidation)
+	if err != nil {
+		entry.Error = err
+		return entry
+	}
+
+	reg, err := name.NewRegistry(dstRegistry)
+	if err != nil {
+		entry.Error = err
+		return entry
+	}
+
+	repo := reg.Repo(ref.Context().RepositoryStr())
+	dst := repo.Tag(ref.Identifier()).String()
+
+	ctx := context.TODO()
+
+	// Reset stdout/stderr to avoid verbose output from cosign.
+	i.m.Lock()
+	stdout := os.Stdout
+	stderr := os.Stderr
+	os.Stdout = nil
+	os.Stderr = nil
+
+	// We shouldn't copy signatures if the image isn't there, so copy images
+	// but don't override them if they are already present.
+	err = copySignature(ctx, srcImg, dst, true)
+	if err != nil {
+		entry.Error = err
+	}
+	entry.Signed = (err == nil)
+
+	os.Stdout = stdout
+	os.Stderr = stderr
+	i.m.Unlock()
+
+	return entry
+}
+
+func signatureSource(srcRef name.Reference, tag string) string {
+	repo := srcRef.Context().RepositoryStr()
+	if upstream, found := externalImages[repo]; found {
+		return fmt.Sprintf("%s:%s", upstream, tag)
+	}
+
+	// Fully qualified reference: <registry>/<repository>:<signature_tag>
+	return fmt.Sprintf("%s:%s", srcRef.Context().Name(), tag)
+}
+
+func copySignature(ctx context.Context, srcImgRef, dstImgRef string, copyImage bool) error {
+	fmt.Println(srcImgRef, dstImgRef)
+	if copyImage {
+		err := crane.Copy(srcImgRef, dstImgRef,
+			crane.WithContext(ctx),
+			crane.WithNoClobber(true)) // ensure tags won't be overwritten.
+
+		if err != nil && !strings.Contains(err.Error(), "refusing to clobber existing tag") {
+			return fmt.Errorf("failed to copy image from %q to %q: %w",
+				srcImgRef, dstImgRef, err)
+		}
+	}
+
+	digest, err := crane.Digest(srcImgRef)
+	if err != nil {
+		return fmt.Errorf("failed to get signed image digest for %q: %w", srcImgRef, err)
+	}
+
+	sourceRef, err := name.ParseReference(srcImgRef)
+	if err != nil {
+		return fmt.Errorf("failed to parse source image reference: %w", err)
+	}
+
+	hex := strings.TrimPrefix(digest, "sha256:")
+	signatureTag := fmt.Sprintf("sha256-%s.sig", hex)
+	sourceSigRef := signatureSource(sourceRef, signatureTag)
+
+	targetRef, err := name.ParseReference(dstImgRef)
+	if err != nil {
+		return fmt.Errorf("failed to parse target image reference: %w", err)
+	}
+
+	dstSigRef := fmt.Sprintf("%s:%s", targetRef.Context().Name(), signatureTag)
+	err = crane.Copy(sourceSigRef, dstSigRef,
+		crane.WithContext(ctx),
+		crane.WithNoClobber(true), // ensure existing signatures won't be overwritten.
+	)
+	if err != nil && !strings.Contains(err.Error(), "refusing to clobber existing tag") {
+		return fmt.Errorf("failed to copy signature from %q to %q: %w", sourceSigRef, dstSigRef, err)
+	}
+
+	return nil
+}

--- a/internal/imagelist/copier_test.go
+++ b/internal/imagelist/copier_test.go
@@ -1,0 +1,84 @@
+package imagelist
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverrideSignatureSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		image string
+		want  string
+	}{
+		{
+			image: "rancher/rancher",
+			want:  "index.docker.io/rancher/rancher",
+		},
+		{
+			image: "127.0.0.1:5000/sig-storage/snapshot-controller",
+			want:  "registry.k8s.io/sig-storage/snapshot-controller",
+		},
+		{
+			image: "127.0.0.1:5000/sig-storage/snapshot-validation-webhook",
+			want:  "registry.k8s.io/sig-storage/snapshot-validation-webhook",
+		},
+		{
+			image: "127.0.0.1:5000/rancher/mirrored-sig-storage-csi-node-driver-registrar",
+			want:  "registry.k8s.io/sig-storage/csi-node-driver-registrar",
+		},
+		{
+			image: "127.0.0.1:5000/rancher/mirrored-sig-storage-csi-attacher",
+			want:  "registry.k8s.io/sig-storage/csi-attacher",
+		},
+		{
+			image: "127.0.0.1:5000/rancher/mirrored-sig-storage-csi-provisioner",
+			want:  "registry.k8s.io/sig-storage/csi-provisioner",
+		},
+		{
+			image: "127.0.0.1:5000/rancher/mirrored-sig-storage-csi-resizer",
+			want:  "registry.k8s.io/sig-storage/csi-resizer",
+		},
+		{
+			image: "127.0.0.1:5000/rancher/mirrored-sig-storage-csi-snapshotter",
+			want:  "registry.k8s.io/sig-storage/csi-snapshotter",
+		},
+		{
+			image: "127.0.0.1:5000/rancher/mirrored-sig-storage-livenessprobe",
+			want:  "registry.k8s.io/sig-storage/rancher/mirrored-sig-storage-livenessprobe",
+		},
+		{
+			image: "127.0.0.1:5000/rancher/mirrored-sig-storage-snapshot-controller",
+			want:  "registry.k8s.io/sig-storage/snapshot-controller",
+		},
+		{
+			image: "127.0.0.1:5000/rancher/mirrored-longhornio-csi-attacher",
+			want:  "registry.k8s.io/sig-storage/csi-attacher",
+		},
+		{
+			image: "127.0.0.1:5000/rancher/appco-redis",
+			want:  "dp.apps.rancher.io/containers/redis",
+		},
+		{
+			image: "127.0.0.1:5000/rancher/mirrored-cilium-cilium",
+			want:  "quay.io/cilium/cilium",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.image, func(t *testing.T) {
+			t.Parallel()
+
+			tag := "sha256-aabbeedd.sig"
+			srcRef, err := name.ParseReference(tc.image + ":" + tag)
+			require.NoError(t, err)
+
+			got := signatureSource(srcRef, tag)
+			assert.Equal(t, tc.want+":"+tag, got)
+		})
+	}
+}

--- a/internal/imagelist/verifier.go
+++ b/internal/imagelist/verifier.go
@@ -7,10 +7,6 @@ import (
 	"github.com/rancherlabs/slsactl/pkg/verify"
 )
 
-type ImageProcessor interface {
-	Verify(img string) Entry
-}
-
 type imageVerifier struct {
 	m sync.Mutex
 }

--- a/internal/product/copy.go
+++ b/internal/product/copy.go
@@ -1,0 +1,61 @@
+package product
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"text/tabwriter"
+
+	"github.com/rancherlabs/slsactl/internal/imagelist"
+)
+
+func Copy(registry, name, version, targetRegistry string) error {
+	info, err := product(name, version)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Copying %s %s signatures to %q:\n\n", info.description, version, targetRegistry)
+
+	p := imagelist.NewProcessor(registry)
+	result, err := p.Copy(fmt.Sprintf(info.imagesUrl, version), targetRegistry)
+	if err != nil {
+		return err
+	}
+
+	result.Product = name
+	result.Version = version
+
+	if len(info.windowsImagesUrl) > 0 {
+		r2, err := p.Copy(fmt.Sprintf(info.windowsImagesUrl, version), targetRegistry)
+		if err == nil {
+			result.Entries = append(result.Entries, r2.Entries...)
+		} else {
+			slog.Error("failed to process windows images", "error", err)
+		}
+	}
+
+	err = printCopySummary(result)
+	if err != nil {
+		return fmt.Errorf("failed to print summary: %w", err)
+	}
+
+	fn := fmt.Sprintf("%s_%s_copy.json", result.Product, result.Version)
+	return saveOutput(fn, result)
+}
+
+func printCopySummary(result *imagelist.Result) error {
+	w := new(tabwriter.Writer)
+	w.Init(os.Stdout, 12, 12, 4, ' ', 0)
+
+	fmt.Print("\n\n ✨ COPY SUMMARY ✨ \n")
+	fmt.Fprintln(w, "Image Type\tImages Count\tSignatures")
+	fmt.Fprintln(w, "-----------\t------------\t------------")
+
+	s := resultSummary(result)
+	for name, data := range s {
+		fmt.Fprintf(w, "%s\t%d \t%d\n", name, data.count, data.signed)
+	}
+
+	return w.Flush()
+}


### PR DESCRIPTION
This enables the copying of signatures from mirrored images which were not copied over during the image sync process.

At present it will only copy mirrored images.