### PR TITLE
Improve cni-plugins verification

### DIFF
--- a/pkg/internal/gha/mapping.go
+++ b/pkg/internal/gha/mapping.go
@@ -70,6 +70,7 @@ var (
 		"rancher/image-build-etcd":                                        "^https://github.com/rancher/image-build-etcd/.github/workflows/(image-push|release).yml@refs/tags/v",
 		"rancher/image-build-whereabouts":                                 "^https://github.com/rancher/image-build-whereabouts/.github/workflows/(image-push|release).yml@refs/tags/v",
 		"rancher/image-build-rke2-cloud-provider":                         "^https://github.com/rancher/image-build-rke2-cloud-provider/.github/workflows/(image-push|release).yml@refs/tags/v",
+		"rancher/image-build-cni-plugins":                                 "^https://github.com/rancher/image-build-cni-plugins/.github/workflows/(image-push|release).yml@refs/tags/v",
 		"rancher/supportability-review":                                   "https://github.com/rancher/supportability-review/.github/workflows/release.yaml@refs/tags/v",
 	}
 


### PR DESCRIPTION
The cni-plugins image is now released by a new workflow identity. To ensure that both new and previous images can be verified, make its identity regex more flexible.

x-ref: https://github.com/rancher/image-build-cni-plugins/pull/81