### PR TITLE
build: Disable cache for the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
       attestations: write # write GH attestations
 
     steps:
+      - name: Delete tooling cache
+        run: |
+          ls -lah /opt/hostedtoolcache
+          rm -rf /opt/hostedtoolcache
+
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -26,6 +31,7 @@ jobs:
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: stable
+          cache: false
 
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 


### PR DESCRIPTION
The release workflow may fail at times due to the runner running out of space. This changes removes all the tooling cache, and also disable the Go caching mechanism. This may increase the release time, but on the other hand will decrease the changes of running out of space during that process.