### PR TITLE
verify: Remove warning when digest is used

### DIFF
--- a/pkg/internal/gha/verifier.go
+++ b/pkg/internal/gha/verifier.go
@@ -72,7 +72,6 @@ func getImageRepoRef(imageName string) (string, string, error) {
 	}
 
 	if strings.Contains(imageName, "@") {
-		fmt.Println("warn: image name with digest is not supported, use tags only.")
 		imageName = strings.Split(imageName, "@")[0]
 	}
 


### PR DESCRIPTION
Fully qualified image names, including tag and digest, previously would show a warning:
`warn: image name with digest is not supported, use tags only.`

This warning has been removed, instead an error is returned if no tag is provided.