### PR TITLE
sanitize system-agent-installer tags

### DIFF
--- a/pkg/internal/gha/verifier.go
+++ b/pkg/internal/gha/verifier.go
@@ -136,11 +136,18 @@ func getCertIdentity(imageName string) (string, error) {
 		return "", fmt.Errorf("failed to parse image name: %w", err)
 	}
 
-	// RKE2 images have container image tags <VERSION>-rke2r1 which are
-	// generated from Git tags <VERSION>+rke2r1. Around version v1.33.0,
-	// the &#43; was replaced with +.
-	if strings.HasPrefix(repo, "rancher/rke2") {
-		ref = strings.Replace(ref, "-rke2", "(\\+|&#43;)rke2", 1)
+	// Images built from git tags whose build meta is separated with +
+	// Until approximately version 1.33.0, &#43; was used instead
+	replaceMeta := map[string]string{
+		"rancher/rke2":                        "-rke2",
+		"rancher/rke2-upgrade":                "-rke2",
+		"rancher/system-agent-installer-rke2": "-rke2",
+		"rancher/system-agent-installer-k3s":  "-k3s",
+	}
+	for r, meta := range replaceMeta {
+		if strings.HasPrefix(repo, r) {
+			ref = strings.Replace(ref, meta, "(\\+|&#43;)"+meta[1:], 1)
+		}
 	}
 
 	// neuvector images don't have "v" prefix like its Git tags

--- a/pkg/internal/gha/verifier_test.go
+++ b/pkg/internal/gha/verifier_test.go
@@ -61,6 +61,26 @@ func TestCertificateIdentity(t *testing.T) {
 			want:  "^https://github.com/rancher/rke2/.github/workflows/release.(yml|yaml)@refs/tags/v0.0.7$",
 		},
 		{
+			image: "rancher/rke2-upgrade:v1.31.14-rke2r1",
+			want:  "^https://github.com/rancher/rke2-upgrade/.github/workflows/release.(yml|yaml)@refs/tags/v1.31.14(\\+|&#43;)rke2r1$",
+		},
+		{
+			image: "rancher/system-agent-installer-k3s:v1.31.14-k3s1",
+			want:  "^https://github.com/rancher/system-agent-installer-k3s/.github/workflows/release.(yml|yaml)@refs/tags/v1.31.14(\\+|&#43;)k3s1$",
+		},
+		{
+			image: "rancher/system-agent-installer-k3s:v1.31.14-k3s1-linux-amd64",
+			want:  "^https://github.com/rancher/system-agent-installer-k3s/.github/workflows/release.(yml|yaml)@refs/tags/v1.31.14(\\+|&#43;)k3s1$",
+		},
+		{
+			image: "rancher/system-agent-installer-rke2:v1.31.14-rke2r1",
+			want:  "^https://github.com/rancher/system-agent-installer-rke2/.github/workflows/release.(yml|yaml)@refs/tags/v1.31.14(\\+|&#43;)rke2r1$",
+		},
+		{
+			image: "rancher/system-agent-installer-rke2:v1.31.14-rke2r1-linux-amd64",
+			want:  "^https://github.com/rancher/system-agent-installer-rke2/.github/workflows/release.(yml|yaml)@refs/tags/v1.31.14(\\+|&#43;)rke2r1$",
+		},
+		{
 			image: "rancher/rke2:v0.0.7-rke2foo2",
 			want:  "^https://github.com/rancher/rke2/.github/workflows/release.(yml|yaml)@refs/tags/v0.0.7(\\+|&#43;)rke2foo2$",
 		},


### PR DESCRIPTION
`slsactl download provenance` is failing in release workflows for rancher/system-agent-installer-k3s and for rancher/system-agent-installer-rke2.

Currently, the gha verifier replaces a dash with a "+" when building the cert identity regular expression for the images rke2 and rke2-upgrade. This PR includes system-agent-installer-rke2 and system-agent-installer-k3s. 

Like rke2 and rke2-upgrade, those repos are also tagged with a "+" in the tag name, which is sanitized and replaced with "-" when building the container image.