### PR TITLE
Add CopyImage function to copy container images with cosign signatures

### DIFF
--- a/internal/imagelist/copier.go
+++ b/internal/imagelist/copier.go
@@ -131,11 +131,13 @@ func CopySignature(ctx context.Context, srcImgRef, dstImgRef string, copyImage b
 	sourceSigRef := signatureSource(sourceRef, signatureTag)
 
 	// check old format first (with .sig suffix)
-	if _, err := crane.Manifest(sourceSigRef, crane.WithContext(ctx)); err != nil {
+	_, err = crane.Manifest(sourceSigRef, crane.WithContext(ctx))
+	if err != nil {
 		// try one last time for the new format (no .sig suffix)
 		signatureTag = strings.TrimSuffix(signatureTag, ".sig")
 		sourceSigRef = strings.TrimSuffix(sourceSigRef, ".sig")
-		if _, err := crane.Manifest(sourceSigRef, crane.WithContext(ctx)); err != nil {
+		_, err = crane.Manifest(sourceSigRef, crane.WithContext(ctx))
+		if err != nil {
 			return fmt.Errorf("tried old/new formats, no manifest found for %s - %w", srcImgRef, err)
 		}
 	}
@@ -154,10 +156,11 @@ func CopySignature(ctx context.Context, srcImgRef, dstImgRef string, copyImage b
 
 	dstSigRef := fmt.Sprintf("%s:%s", targetRef.Context().Name(), signatureTag)
 
-	if err := crane.Copy(sourceSigRef, dstSigRef,
+	err = crane.Copy(sourceSigRef, dstSigRef,
 		crane.WithContext(ctx),
 		crane.WithNoClobber(true), // ensure existing signatures won't be overwritten.
-	); err != nil && !strings.Contains(err.Error(), "refusing to clobber existing tag") {
+	)
+	if err != nil && !strings.Contains(err.Error(), "refusing to clobber existing tag") {
 		return fmt.Errorf("failed to copy signature from %q to %q: %w", sourceSigRef, dstSigRef, err)
 	}
 

--- a/pkg/imagecopy/copy.go
+++ b/pkg/imagecopy/copy.go
@@ -1,4 +1,4 @@
-package copy
+package imagecopy
 
 import (
 	"context"


### PR DESCRIPTION
Issue: https://github.com/rancher/ecm-distro-tools/issues/727

Introduces a new public API in pkg/copy for copying individual container images along with their cosign signatures between OCI registries.

Key features:
- Supports both legacy (.sig suffix) and new OCI artifact signature formats
- Implements NoClobber to prevent accidental tag overwrites
- Validates that source and target tags match to prevent signature misuse
- Automatically detects signature format using manifest checks
- Provides clear error messages for missing signatures

The function is designed for use in automation workflows where signed images need to be mirrored between registries while preserving their cryptographic signatures for verification.

Example usage:
```
  copy.CopyImage(
    "source-registry.com/repo/image:v1.0.0",
    "target-registry.com/repo/image:v1.0.0",
  )
```  