### PR TITLE
Copy images before checking for signatures

### DIFF
--- a/internal/imagelist/copier.go
+++ b/internal/imagelist/copier.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
-// ErrNoSignaturesFound indicates no signature was found for the image
+// ErrNoSignaturesFound indicates no signature was found for the image.
 var ErrNoSignaturesFound = errors.New("no signatures found")
 
 var externalImages = map[string]string{
@@ -148,9 +148,8 @@ func CopySignature(ctx context.Context, srcImgRef, dstImgRef string, copyImage b
 		signatureTag = strings.TrimSuffix(signatureTag, ".sig")
 		sourceSigRef = strings.TrimSuffix(sourceSigRef, ".sig")
 		_, err = crane.Manifest(sourceSigRef, crane.WithContext(ctx))
-
 		if err != nil {
-			return fmt.Errorf("%w: %w", ErrSignatureNotFound, err)
+			return fmt.Errorf("%w: %w", ErrNoSignaturesFound, err)
 		}
 	}
 

--- a/pkg/imagecopy/copy.go
+++ b/pkg/imagecopy/copy.go
@@ -2,13 +2,12 @@ package imagecopy
 
 import (
 	"context"
-	"errors"
 
 	"github.com/rancherlabs/slsactl/internal/imagelist"
 )
 
-// ErrSignatureNotFound indicates no signature was found for the image
-var ErrSignatureNotFound = imagelist.ErrSignatureNotFound
+// ErrNoSignaturesFound indicates no signature was found for the image.
+var ErrNoSignaturesFound = imagelist.ErrNoSignaturesFound
 
 // ImageAndSignature copies a single container image with its cosign signature from source
 // to target registry. The source and target must be fully qualified image references


### PR DESCRIPTION
Issue: https://github.com/rancher/ecm-distro-tools/issues/727

Moves image copy operation before signature validation to support copying unsigned images. Previously, if signature detection failed, the image would not be copied at all.

Extracts crane.Copy calls into a shared copy() helper function to reduce code duplication between image and signature copy operations.