### PR TITLE
add mapping for turtles release

### DIFF
--- a/pkg/internal/gha/mapping.go
+++ b/pkg/internal/gha/mapping.go
@@ -84,6 +84,7 @@ var (
 		"rancher/supportability-review":                                   "^https://github.com/rancher/supportability-review/.github/workflows/release.yaml@refs/tags/v",
 		"rancher/rancher-prime":                                           "^https://github.com/rancher/rancher-prime/.github/workflows/(release|alpha-release|rc-release).yml@refs/tags/v",
 		"rancher/prometheus-federator":                                    "^https://github.com/rancher/prometheus-federator/.github/workflows/(release|publish).yaml@refs/tags/v",
+		"rancher/turtles":                                                 "^https://github.com/rancher/turtles/.github/workflows/(release-v2|release).yaml@refs/tags/v",
 	}
 
 	// imageSuffixes holds a mapping between image name and the ref suffixes


### PR DESCRIPTION
# Description

[Turtles](https://github.com/rancher/turtles) has been using `release-v2.yaml` as release workflow filename and it has already produced images from this file. This mapping should address the issue for existing images and also support renaming the YAML file to `release.yaml` in the future.