### PR TITLE
Add core CAPI images to mapping list

### DIFF
--- a/pkg/internal/gha/mapping.go
+++ b/pkg/internal/gha/mapping.go
@@ -64,6 +64,8 @@ var (
 		"rancher/cluster-api-addon-provider-fleet":                        "^https://github.com/rancher/clusterapi-forks/.github/workflows/caapf.yaml@refs/heads/main$",
 		"rancher/ip-address-manager":                                      "^https://github.com/rancher/clusterapi-forks/.github/workflows/metal3-ipam.yaml@refs/heads/main$",
 		"rancher/cluster-api-controller":                                  "^https://github.com/rancher/clusterapi-forks/.github/workflows/core.yaml@refs/heads/main$",
+		"rancher/kubeadm-bootstrap-controller":                            "^https://github.com/rancher/clusterapi-forks/.github/workflows/core.yaml@refs/heads/main$",
+		"rancher/kubeadm-control-plane-controller":                        "^https://github.com/rancher/clusterapi-forks/.github/workflows/core.yaml@refs/heads/main$",
 		"rancher/cluster-api-aws-controller":                              "^https://github.com/rancher/clusterapi-forks/.github/workflows/aws.yaml@refs/heads/main$",
 		"rancher/cluster-api-azure-controller":                            "^https://github.com/rancher/clusterapi-forks/.github/workflows/azure.yaml@refs/heads/main$",
 		"rancher/cluster-api-gcp-controller":                              "^https://github.com/rancher/clusterapi-forks/.github/workflows/gcp.yaml@refs/heads/main$",


### PR DESCRIPTION
Add 'kubeadm-bootstrap-controller' and 'kubeadm-control-plane-controller' images to mapping. 

When building downstream images for core CAPI images using slsactl, we are seeing following error when building 'kubeadm-bootstrap-controller' and 'kubeadm-control-plane-controller' images:

```
set -e
  
  max_retries=3
  retry_delay=10
  
  for i in $(seq 1 $max_retries); do
    if slsactl download provenance --format=slsav1 "***/***/kubeadm-bootstrap-controller:v1.11.4@$MANIFEST_DIGEST" | tee provenance-slsav1.json; then
      break
    fi
    
    if [ $i -eq $max_retries ]; then
      echo "ERROR: Failed to generate slsav1 provenance after $max_retries attempts"
      echo "Check whether the image is present in the Prime registry."
      exit 1
    fi
    
    echo "Provenance download attempt $i failed, retrying in ${retry_delay}s..."
    sleep $retry_delay
  done
  
  echo "Generated provenance:"
  cat provenance-slsav1.json
  
  echo "Attesting provenance..."
  cosign attest --yes --predicate provenance-slsav1.json --type slsaprovenance1 "***/***/kubeadm-bootstrap-controller@$MANIFEST_DIGEST"
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    GH_REPOSITORY: ***-sandbox/cluster-api
    REPO_PATH: cluster-api
    ARTIFACT_NAME: cluster-api-controller
    CERTIFICATE_IDENTITY: https://github.com/***/clusterapi-forks/.github/workflows/core.yaml@refs/heads/main
    ALL_ARCH: linux/amd64,linux/arm64
    PRIME_REGISTRY: ***
    PRIME_REGISTRY_USERNAME: ***
    PRIME_REGISTRY_SECRET: ***
    DOCKER_USERNAME: ***
    DOCKER_PASSWORD: ***
    MANIFEST_DIGEST: sha256:400977ca9f7dd529dda8f86e24e5fe5d59e73d288286759bbe0d870fb7b0fac9
failed to run download: failed to verify "***/***/kubeadm-bootstrap-controller:v1.11.4@sha256:400977ca9f7dd529dda8f86e24e5fe5d59e73d288286759bbe0d870fb7b0fac9": no matching signatures: none of the expected identities matched what was in the certificate, got subjects [https://github.com/***/clusterapi-forks/.github/workflows/core.yaml@refs/heads/main] with issuer https://token.actions.githubusercontent.com/
Provenance download attempt 1 failed, retrying in 10s...
failed to run download: failed to verify "***/***/kubeadm-bootstrap-controller:v1.11.4@sha256:400977ca9f7dd529dda8f86e24e5fe5d59e73d288286759bbe0d870fb7b0fac9": no matching signatures: none of the expected identities matched what was in the certificate, got subjects [https://github.com/***/clusterapi-forks/.github/workflows/core.yaml@refs/heads/main] with issuer https://token.actions.githubusercontent.com/
Provenance download attempt 2 failed, retrying in 10s...
failed to run download: failed to verify "***/***/kubeadm-bootstrap-controller:v1.11.4@sha256:400977ca9f7dd529dda8f86e24e5fe5d59e73d288286759bbe0d870fb7b0fac9": no matching signatures: none of the expected identities matched what was in the certificate, got subjects [https://github.com/***/clusterapi-forks/.github/workflows/core.yaml@refs/heads/main] with issuer https://token.actions.githubusercontent.com/
ERROR: Failed to generate slsav1 provenance after 3 attempts
Check whether the image is present in the Prime registry.
Error: Process completed with exit code 1.
```

while core capi image rancher/cluster-api-controller is built just fine. 