### PR TITLE
Add mappings for kubewarden monorepo

### DIFF
--- a/pkg/internal/gha/mapping.go
+++ b/pkg/internal/gha/mapping.go
@@ -93,6 +93,8 @@ var (
 		"rancher/rancher-webhook":                                         "^https://github.com/rancher/webhook/.github/workflows/release.ya?ml@refs/tags/v",
 		"rancher/prometheus-federator":                                    "^https://github.com/rancher/prometheus-federator/.github/workflows/(release|publish).yaml@refs/tags/v",
 		"rancher/turtles":                                                 "^https://github.com/rancher/turtles/.github/workflows/(release-v2|release).ya?ml@refs/tags/v",
+		"kubewarden/policy-server":                                        "^https://github.com/kubewarden/(policy-server|kubewarden-controller)/.github/workflows/release.ya?ml@refs/tags/v",
+		"kubewarden/audit-scanner":                                        "^https://github.com/kubewarden/(audit-scanner|kubewarden-controller)/.github/workflows/release.ya?ml@refs/tags/v",
 	}
 
 	// imageSuffixes holds a mapping between image name and the ref suffixes


### PR DESCRIPTION
Some Kubewarden images moved to the mono repository: kubewarden/kubewarden-controller. The new mappings take that into account and ensure that both previous and new repositories are accepted for the affected images.