### PR TITLE
add system-agent image suffixes

### DIFF
--- a/pkg/internal/gha/mapping.go
+++ b/pkg/internal/gha/mapping.go
@@ -104,5 +104,10 @@ var (
 	// subject identity.
 	imageSuffixes = map[string][]string{
 		"rancher/hardened-multus-cni": {"-arch"},
+		"rancher/system-agent": {
+			"-linux-amd64-suc",
+			"-linux-arm64-suc",
+			"-suc",
+		},
 	}
 )

--- a/pkg/internal/gha/verifier_test.go
+++ b/pkg/internal/gha/verifier_test.go
@@ -170,6 +170,18 @@ func TestCertificateIdentity(t *testing.T) {
 			want:  "^https://github.com/rancher/system-agent-installer-k3s/.github/workflows/release.(yml|yaml)@refs/tags/v1.34.2\\+k3s1$",
 		},
 		{
+			image: "rancher/system-agent:v0.3.16-rc.2-linux-amd64-suc",
+			want:  "^https://github.com/rancher/system-agent/.github/workflows/release.(yml|yaml)@refs/tags/v0.3.16-rc.2$",
+		},
+		{
+			image: "rancher/system-agent:v0.3.16-rc.2-linux-arm64-suc",
+			want:  "^https://github.com/rancher/system-agent/.github/workflows/release.(yml|yaml)@refs/tags/v0.3.16-rc.2$",
+		},
+		{
+			image: "rancher/system-agent:v0.3.16-rc.2-suc",
+			want:  "^https://github.com/rancher/system-agent/.github/workflows/release.(yml|yaml)@refs/tags/v0.3.16-rc.2$",
+		},
+		{
 			image: "rancher/system-agent-installer-rke2:v1.34.2-rke2r1-windows-ltsc2022-amd64",
 			want:  "^https://github.com/rancher/system-agent-installer-rke2/.github/workflows/release.(yml|yaml)@refs/tags/v1.34.2\\+rke2r1$",
 		},


### PR DESCRIPTION
## Problem
`slsactl download provenance --format=slsav1` was failing for signed `rancher/system-agent` SUC images because the verifier was deriving the expected GitHub Actions certificate identity from the full image tag instead of the underlying Git tag.

For:
`rancher/system-agent:v0.3.16-rc.2-linux-amd64-suc`

it expected:
`...@refs/tags/v0.3.16-rc.2-linux-amd64-suc`

but the actual cert SAN was:
`...@refs/tags/v0.3.16-rc.2`

Observed error:
```text
no matching attestations: failed to verify certificate identity: no matching CertificateIdentity found, last error: expected SAN value to match regex "^https://github.com/rancher/system-agent/.github/workflows/release.(yml|yaml)@refs/tags/v0.3.16-rc.2-linux-amd64-suc$
", got "https://github.com/rancher/system-agent/.github/workflows/release.yaml@refs/tags/v0.3.16-rc.2"
```
## Solution

Add rancher/system-agent-specific suffix normalization so the expected certificate identity is built from the real release tag.

Trimmed suffixes:

- -linux-amd64-suc
- -linux-arm64-suc
- -suc

Also added unit coverage for the affected tag variants.

## Testing

## Engineering Testing

### Manual Testing

- Reproduced the failure with a pre-fix binary
- Built slsactl locally and verified the fixed binary succeeds with:
  `slsactl download provenance --format=slsav1 <registry>/rancher/system-agent:v0.3.16-rc.2-linux-amd64-suc`
- Confirmed the returned provenance metadata references refs/tags/v0.3.16-rc.2

### Automated Testing

- Test types added/modified:
    - Unit
    
- Validated with:
	- go test ./pkg/internal/gha
