### PR TITLE
feat(gha): add verification support for kubewarden adm-controller images

### DIFF
--- a/pkg/internal/gha/mapping.go
+++ b/pkg/internal/gha/mapping.go
@@ -97,6 +97,9 @@ var (
 		"rancher/turtles":                                                 "^https://github.com/rancher/turtles/.github/workflows/(release-v2|release).ya?ml@refs/tags/v",
 		"kubewarden/policy-server":                                        "^https://github.com/kubewarden/(policy-server|kubewarden-controller)/.github/workflows/release.ya?ml@refs/tags/v",
 		"kubewarden/audit-scanner":                                        "^https://github.com/kubewarden/(audit-scanner|kubewarden-controller)/.github/workflows/release.ya?ml@refs/tags/v",
+		"adm-controller/policy-server":                                    "^https://github.com/kubewarden/adm-controller/.github/workflows/release.ya?ml@refs/tags/v",
+		"adm-controller/audit-scanner":                                    "^https://github.com/kubewarden/adm-controller/.github/workflows/release.ya?ml@refs/tags/v",
+		"adm-controller/controller":                                       "^https://github.com/kubewarden/adm-controller/.github/workflows/release.ya?ml@refs/tags/v",
 	}
 
 	// imageSuffixes holds a mapping between image name and the ref suffixes

--- a/pkg/internal/gha/verifier_test.go
+++ b/pkg/internal/gha/verifier_test.go
@@ -193,6 +193,26 @@ func TestCertificateIdentity(t *testing.T) {
 			image: "rancher/system-agent-installer-rke2:v1.34.2-rke2r1-windows-1809-arm64",
 			want:  "^https://github.com/rancher/system-agent-installer-rke2/.github/workflows/release.(yml|yaml)@refs/tags/v1.34.2\\+rke2r1$",
 		},
+		{
+			image: "ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0-alpha",
+			want:  "^https://github.com/kubewarden/adm-controller/.github/workflows/release.ya?ml@refs/tags/v",
+		},
+		{
+			image: "ghcr.io/kubewarden/adm-controller/audit-scanner:v1.36.0-alpha",
+			want:  "^https://github.com/kubewarden/adm-controller/.github/workflows/release.ya?ml@refs/tags/v",
+		},
+		{
+			image: "ghcr.io/kubewarden/adm-controller/controller:v1.36.0-alpha",
+			want:  "^https://github.com/kubewarden/adm-controller/.github/workflows/release.ya?ml@refs/tags/v",
+		},
+		{
+			image: "ghcr.io/kubewarden/policy-server:v1.19.0",
+			want:  "^https://github.com/kubewarden/(policy-server|kubewarden-controller)/.github/workflows/release.ya?ml@refs/tags/v",
+		},
+		{
+			image: "ghcr.io/kubewarden/audit-scanner:v1.19.0",
+			want:  "^https://github.com/kubewarden/(audit-scanner|kubewarden-controller)/.github/workflows/release.ya?ml@refs/tags/v",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Fix identityOverride keys for adm-controller images to match the truncated repository path returned by getImageRepoRef. The function returns the last two path components for 3-level repos, so keys must use adm-controller/policy-server instead of the full path.

Add verification entry for the new controller image and test cases for both old (ghcr.io/kubewarden/policy-server) and new (ghcr.io/kubewarden/adm-controller/*) image paths.

Part of https://github.com/kubewarden/adm-controller/issues/1657
