### PR TITLE
chore: add CAPRKE2 to image repo mapping

### DIFF
--- a/pkg/internal/gha/mapping.go
+++ b/pkg/internal/gha/mapping.go
@@ -57,6 +57,8 @@ var (
 		"rancher/neuvector-compliance-config":                 "neuvector/compliance-config",
 		"rancher/supportability-review-internal":              "rancher/supportability-review",
 		"rancher/supportability-review-app-frontend":          "rancher/supportability-review-operator",
+		"rancher/cluster-api-provider-rke2-bootstrap":         "rancher/cluster-api-provider-rke2",
+		"rancher/cluster-api-provider-rke2-controlplane":      "rancher/cluster-api-provider-rke2",
 	}
 
 	mutableRepo = map[string]bool{

--- a/pkg/internal/gha/verifier_test.go
+++ b/pkg/internal/gha/verifier_test.go
@@ -213,6 +213,14 @@ func TestCertificateIdentity(t *testing.T) {
 			image: "ghcr.io/kubewarden/audit-scanner:v1.19.0",
 			want:  "^https://github.com/kubewarden/(audit-scanner|kubewarden-controller)/.github/workflows/release.ya?ml@refs/tags/v",
 		},
+		{
+			image: "rancher/cluster-api-provider-rke2-bootstrap:v0.24.3",
+			want:  "^https://github.com/rancher/cluster-api-provider-rke2/.github/workflows/release.(yml|yaml)@refs/tags/v0.24.3$",
+		},
+		{
+			image: "rancher/cluster-api-provider-rke2-controlplane:v0.24.3",
+			want:  "^https://github.com/rancher/cluster-api-provider-rke2/.github/workflows/release.(yml|yaml)@refs/tags/v0.24.3$",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Provenance verification fails for [CAPRKE2](https://github.com/rancher/cluster-api-provider-rke2) images because slsactl derives the expected GitHub repository from the image name. The two published images: 
- rancher/cluster-api-provider-rke2-bootstrap 
- rancher/cluster-api-provider-rke2-controlplane 
 
have suffixes (-bootstrap & -controlplane) that don't exist in the source repository name (rancher/cluster-api-provider-rke2), causing a mismatch, see the [error below](https://github.com/furkatgofurov7/cluster-api-provider-rke2/actions/runs/25665970289/job/75338381879):

```
failed to run download: failed to verify "ghcr.io/furkatgofurov7/cluster-api-provider-rke2-bootstrap:v0.99.3-test@sha256:d2a77b7ae5feb5d7afba6e25050087e08d91872239fb9da64a0cd2506d931428": no matching attestations: failed to verify certificate identity: no matching CertificateIdentity found, last error: expected SAN value to match regex "^https://github.com/furkatgofurov7/cluster-api-provider-rke2-bootstrap/.github/workflows/release.(yml|yaml)@refs/tags/v0.99.3-test$", got "https://github.com/furkatgofurov7/cluster-api-provider-rke2/.github/workflows/release.yml@refs/tags/v0.99.3-test"
Error: Process completed with exit code 1.

```