### PR TITLE
Add fallback check for image-build-XX repos and add support for hardened-vsphere images

### DIFF
--- a/pkg/internal/gha/mapping.go
+++ b/pkg/internal/gha/mapping.go
@@ -39,6 +39,7 @@ var (
 		"rancher/hardened-traefik":                            "rancher/image-build-traefik",
 		"rancher/hardened-csi-snapshotter":                    "rancher/image-build-external-snapshotter",
 		"rancher/hardened-snapshot-controller":                "rancher/image-build-external-snapshotter",
+		"rancher/hardened-vsphere-csi-syncer":                 "rancher/image-build-vsphere-csi-driver",
 		"rancher/nginx-ingress-controller":                    "rancher/ingress-nginx",
 		"rancher/nginx-ingress-controller-chroot":             "rancher/ingress-nginx",
 		"rancher/kube-webhook-certgen":                        "rancher/ingress-nginx",

--- a/pkg/internal/gha/verifier.go
+++ b/pkg/internal/gha/verifier.go
@@ -180,5 +180,9 @@ func overrideRepo(repo string) string {
 		return v
 	}
 
+	if strings.HasPrefix(repo, "rancher/hardened-") {
+		return strings.Replace(repo, "rancher/hardened-", "rancher/image-build-", 1)
+	}
+
 	return repo
 }

--- a/pkg/internal/gha/verifier_test.go
+++ b/pkg/internal/gha/verifier_test.go
@@ -80,6 +80,10 @@ func TestCertificateIdentity(t *testing.T) {
 			image: "rancher/hardened-multus-dynamic-networks-controller:v0.3.7-build20250711",
 			want:  "^https://github.com/rancher/image-build-multus-dynamic-networks-controller/.github/workflows/release.(yml|yaml)@refs/tags/v0.3.7-build20250711$",
 		},
+		{
+			image: "rancher/hardened-foo:v1.2.3",
+			want:  "^https://github.com/rancher/image-build-foo/.github/workflows/release.(yml|yaml)@refs/tags/v1.2.3$",
+		},
 
 		{
 			image:   "",


### PR DESCRIPTION
- Fallback option in overrideRepo for any future `hardened-XXXX` repos, so we don't need to update this tool every single time we harden a new image. This covers about 85% of existing `image-build-XXX` repos for RKE2. 
- Specific override for `rancher/hardened-vsphere-csi-syncer`
Signed-off-by: Derek Nola <derek.nola@suse.com>